### PR TITLE
Adding support for Gradescope extensions

### DIFF
--- a/bsag/steps/gradescope/_types.py
+++ b/bsag/steps/gradescope/_types.py
@@ -43,10 +43,16 @@ class OutputFormatEnum(str, Enum):
     ANSI = "ansi"
 
 
+class AssignmentUser(BaseModel):
+    release_date: datetime
+    due_date: datetime
+    late_due_date: datetime | None = None
+
 class User(BaseModel):
     email: str
     id: int  # noqa
     name: str
+    assignment: AssignmentUser | None = None
 
 
 class Assignment(BaseModel):

--- a/bsag/steps/gradescope/lateness.py
+++ b/bsag/steps/gradescope/lateness.py
@@ -40,10 +40,11 @@ class Lateness(BaseStepDefinition[LatenessConfig]):
         subm_data: SubmissionMetadata = bsagio.data[METADATA_KEY]
         res: Results = bsagio.data[RESULTS_KEY]
 
-        lateness = max(0, (subm_data.created_at - subm_data.assignment.due_date).total_seconds())
+        lateness = max(0, (subm_data.created_at - subm_data.users[0].assignment.due_date).total_seconds())
         graced_lateness = max(0, lateness - config.grace_period)
 
-        bsagio.private.debug("Due:       " + str(subm_data.assignment.due_date))
+        bsagio.private.debug("Original due date: " + str(subm_data.assignment.due_date))
+        bsagio.private.debug("Due for student:       " + str(subm_data.users[0].assignment.due_date))
         bsagio.private.debug("Submitted: " + str(subm_data.created_at))
 
         if lateness == 0:


### PR DESCRIPTION
We now parse extension data (in the form of the assignment field in each user present within submission_metadata.users), and use this in lateness calculations. This allows us to provide support for extensions added through the Gradescope platform. 